### PR TITLE
添加exec功能，在doc/下添加对应文档

### DIFF
--- a/alaudacli/__init__.py
+++ b/alaudacli/__init__.py
@@ -1,5 +1,4 @@
 __version__ = "0.2.6"
 
-
 def main():
     pass

--- a/alaudacli/alauda_cli.py
+++ b/alaudacli/alauda_cli.py
@@ -9,18 +9,16 @@ from exceptions import AlaudaInputError, AlaudaServerError
 def patch_argv(argv):
     args = copy.copy(argv)
 
-    if not args:  # impossible, the command is args[0]
+    if not args:
         raise AlaudaInputError('Arguments cannot be empty')
 
     if len(args) >= 2:
-        # for example, `alauda create` -> `alauda service create`
         if args[1] in ['create', 'run', 'scale', 'inspect', 'start', 'stop', 'rm',
                        'enable-autoscaling', 'disable-autoscaling', 'logs', 'ps',
-                       'instances', 'instance', 'instance-logs', 'ssh-path', 'exec']:
+                       'instances', 'instance', 'instance-logs', 'exec']:
             args.insert(1, 'service')
 
     if len(args) == 1:
-        # `alauda` -> `alauda -h`
         args.append('-h')
     elif len(args) == 2 and args[1] in ['service', 'compose', 'backup', 'organization']:
         args.append('-h')
@@ -36,7 +34,6 @@ def patch_argv(argv):
         elif args[1] == 'organization' and args[2] in ['create', 'inspect', 'update']:
             args.append('-h')
 
-    # command name is removed
     return args[1:]
 
 

--- a/alaudacli/alauda_cli.py
+++ b/alaudacli/alauda_cli.py
@@ -9,16 +9,18 @@ from exceptions import AlaudaInputError, AlaudaServerError
 def patch_argv(argv):
     args = copy.copy(argv)
 
-    if not args:
+    if not args:  # impossible, the command is args[0]
         raise AlaudaInputError('Arguments cannot be empty')
 
     if len(args) >= 2:
+        # for example, `alauda create` -> `alauda service create`
         if args[1] in ['create', 'run', 'scale', 'inspect', 'start', 'stop', 'rm',
                        'enable-autoscaling', 'disable-autoscaling', 'logs', 'ps',
-                       'instances', 'instance', 'instance-logs']:
+                       'instances', 'instance', 'instance-logs', 'ssh-path', 'exec']:
             args.insert(1, 'service')
 
     if len(args) == 1:
+        # `alauda` -> `alauda -h`
         args.append('-h')
     elif len(args) == 2 and args[1] in ['service', 'compose', 'backup', 'organization']:
         args.append('-h')
@@ -34,6 +36,7 @@ def patch_argv(argv):
         elif args[1] == 'organization' and args[2] in ['create', 'inspect', 'update']:
             args.append('-h')
 
+    # command name is removed
     return args[1:]
 
 

--- a/alaudacli/alauda_cli.py
+++ b/alaudacli/alauda_cli.py
@@ -25,7 +25,7 @@ def patch_argv(argv):
     elif len(args) == 3:
         if args[1] == 'service' and args[2] in ['create', 'run', 'scale', 'inspect', 'start', 'stop', 'rm',
                                                 'enable-autoscaling', 'disable-autoscaling', 'logs',
-                                                'instances', 'instance', 'instance-logs']:
+                                                'instances', 'instance', 'instance-logs', 'exec']:
             args.append('-h')
         elif args[1] == 'compose' and args[2] in ['scale']:
             args.append('-h')

--- a/alaudacli/auth.py
+++ b/alaudacli/auth.py
@@ -4,7 +4,6 @@ import os
 import settings
 from exceptions import AlaudaInputError
 
-
 def get_api_endpoint(cloud):
     return settings.API_ENDPOINTS[cloud]
 

--- a/alaudacli/backup.py
+++ b/alaudacli/backup.py
@@ -4,7 +4,6 @@ import json
 import requests
 from exceptions import AlaudaServerError
 
-
 class Backup(object):
 
     def __init__(self, service=None, name='', mounted_dir='', details=''):

--- a/alaudacli/cmd_parser.py
+++ b/alaudacli/cmd_parser.py
@@ -129,6 +129,13 @@ def _add_service_parser(subparsers):
     logs_instance_parser.add_argument('-e', '--end-time', help='Logs query end time. e.g. 2015-05-01 12:12:12')
     logs_instance_parser.add_argument('-n', '--namespace', help='Service namespace')
 
+    exec_parser = service_subparsers.add_parser('exec', help='Alauda exec', description='Alauda exec')
+    exec_parser.add_argument('-c', '--client', help='The command name of ssh client, support ssh and plink, in the form of <ssh_client>:<client_path>, where <client_path> defaults to the same as ssh_client if absent. The default is ssh', default='ssh')
+    exec_parser.add_argument('-n', '--namespace', help='Service namespace')
+    exec_parser.add_argument('-v', '--verbose', action='store_true', help='show more info')
+    exec_parser.add_argument('container', help='Container instance name, in the form of <service name>.<container number>, where <container number> defaults to 0 if absent')
+    exec_parser.add_argument('command', metavar='command', type=str, nargs='+', help='Command to execute')
+
 
 def _add_backups_parser(subparsers):
     backups_parser = subparsers.add_parser('backup', help='Backup operations', description='Backup operations')

--- a/alaudacli/cmd_processor.py
+++ b/alaudacli/cmd_processor.py
@@ -41,6 +41,8 @@ def process_cmds(args):
             commands.instance_inspect(args.name, args.id, namespace=args.namespace)
         elif args.subcmd == 'instance-logs':
             commands.instance_logs(args.name, args.id, args.namespace, args.start_time, args.end_time)
+        elif args.subcmd == 'exec': # add by letian
+            commands.service_exec(args.client, args.namespace, args.verbose ,args.container, args.command)
     elif args.cmd == 'backup':
         if args.subcmd == 'create':
             commands.backup_create(args.name, args.service, args.dir, args.namespace)

--- a/alaudacli/commands.py
+++ b/alaudacli/commands.py
@@ -8,7 +8,7 @@ import compose
 from service import Service
 from backup import Backup
 from organization import Organization
-
+from execute import execute
 
 def login(username, password, cloud, endpoint):
     if not username:
@@ -19,6 +19,7 @@ def login(username, password, cloud, endpoint):
     api_endpoint = endpoint
     if api_endpoint is None:
         api_endpoint = auth.get_api_endpoint(cloud)
+
     url = api_endpoint + 'generate-api-token/'
     payload = {'username': username, 'password': password}
     r = requests.post(url, payload)
@@ -114,6 +115,10 @@ def service_logs(name, namespace, start_time, end_time):
     service = Service.fetch(name, namespace)
     result = service.logs(start_time, end_time)
     util.print_logs(result)
+
+## add by letian
+def service_exec(ssh_client, namespace, is_verbose, container, command):
+    execute(ssh_client, namespace, is_verbose, container, command)
 
 
 def instance_ps(name, namespace):

--- a/alaudacli/exceptions.py
+++ b/alaudacli/exceptions.py
@@ -1,3 +1,14 @@
+class AlaudaException(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return '[alauda cli exception] {0}'.format(self.message)
+
+    __repr__ = __str__
+
+
 class AlaudaServerError(Exception):
 
     def __init__(self, status_code, message):

--- a/alaudacli/execute.py
+++ b/alaudacli/execute.py
@@ -1,0 +1,137 @@
+import os
+import json
+import requests
+import auth
+from exceptions import AlaudaException
+from exceptions import AlaudaInputError
+import settings
+import util
+
+SSH = 'ssh'
+PLINK = 'plink'
+DEFAULT_EXEC_ENDPOINT = 'exec.alauda.cn'
+VERBOSE = False
+
+def execute(ssh_client, namespace, is_verbose, container, command_list):
+
+    if isinstance(is_verbose, bool):
+        global VERBOSE
+        VERBOSE = is_verbose
+
+    if not namespace:
+        try:
+            _, _, username = auth.load_token()
+            namespace = username
+        except:
+            raise AlaudaInputError('Please login first or specify namespace')
+
+    ssh_client, ssh_client_location = parse_ssh_client_arg(ssh_client)
+    exec_endpoint = get_exec_endpoint(namespace, container)
+
+    args = (ssh_client_location, namespace, exec_endpoint, container, ' '.join(command_list))
+
+    if ssh_client == SSH:
+        # ssh -p 4022 -t USER@exec.alauda.cn CONTAINER COMMAND
+        exec_command = '{0} -p 4022 -t {1}@{2} {3} {4}'.format(*args)
+    elif ssh_client == PLINK:
+        # plink -P 4022 -t USER@exec.alauda.cn CONTAINER COMMAND
+        exec_command = '{0} -P 4022 -t {1}@{2} {3} {4}'.format(*args)
+
+    verbose('namespace: {0}'.format(namespace))
+    verbose('ssh client: {0}'.format(ssh_client))
+    verbose('the path of ssh client: {0}'.format(ssh_client_location))
+    verbose('command: {0}'.format(exec_command))
+
+    os.system(exec_command)
+
+def parse_ssh_client_arg(ssh_client):
+    assert isinstance(ssh_client, str)
+
+    ssh_client_location = None
+    if ':' in ssh_client:
+        arg_split = ssh_client.split(':')
+        ssh_client = arg_split[0]
+        if len(arg_split) > 1:
+            ssh_client_location = ':'.join(arg_split[1:])
+        if ssh_client_location is not None and len(ssh_client_location.strip()) == 0:
+            raise AlaudaInputError('invalid location of ssh client, only support ssh and plink.')
+    else:
+        ssh_client_location = ssh_client
+
+    if ssh_client not in (SSH, PLINK):
+        raise AlaudaInputError('invalid ssh client')
+
+    return ssh_client, ssh_client if ssh_client_location is None else ssh_client_location
+
+
+def parse_container_arg(container):
+    if '.' not in container:
+        service_name = container
+        container_number = 0
+    else:
+        arg_split = container.split('.')
+        try:
+            container_number = int(arg_split[-1])
+            service_name = '.'.join(arg_split[:-1])
+        except:
+            service_name = container
+            container_number = 0
+    return service_name, container_number
+
+
+def get_exec_endpoint(namespace, container):
+
+    try:
+        _, _, username = auth.load_token()
+        if namespace != username:
+            verbose('use default exec endpoint: {0}'.format(DEFAULT_EXEC_ENDPOINT))
+            return DEFAULT_EXEC_ENDPOINT
+    except:
+        verbose('use default exec endpoint: {0}'.format(DEFAULT_EXEC_ENDPOINT))
+        return DEFAULT_EXEC_ENDPOINT
+
+    service_name, _ = parse_container_arg(container)
+    verbose('service name: {0}'.format(service_name))
+
+    try:
+        exec_endpoint = load_exec_endpoint(service_name)
+    except:
+        api_endpoint, token, username = auth.load_token()
+        url = api_endpoint + '/services/{0}/{1}'.format(namespace, service_name)
+        headers = auth.build_headers(token)
+
+        r = requests.get(url, headers=headers)
+        util.check_response(r)
+        data = json.loads(r.text)
+        exec_endpoint = data['exec_endpoint']
+
+        save_exec_endpoint(service_name, exec_endpoint)
+
+    return exec_endpoint
+
+
+def save_exec_endpoint(service_name, exec_endpoint):
+    try:
+        with open(settings.ALAUDACFG, 'r') as f:
+            config = json.load(f)
+    except:
+        config = {}
+    config.setdefault('exec_endpoint', {})
+    config['exec_endpoint'][service_name] = exec_endpoint
+
+    with open(settings.ALAUDACFG, 'w') as f:
+        json.dump(config, f, indent=2)
+
+def load_exec_endpoint(service_name):
+    try:
+        with open(settings.ALAUDACFG, 'r') as f:
+            config = json.load(f)
+            exec_endpoint = config['exec_endpoint'][service_name]
+            return exec_endpoint
+    except:
+        raise AlaudaException('Error occured while loading exec endpoint')
+
+def verbose(message):
+    global VERBOSE
+    if VERBOSE:
+        print '[alauda info] {0}'.format(message)

--- a/doc/how_to_use_exec.md
+++ b/doc/how_to_use_exec.md
@@ -1,0 +1,122 @@
+Exec
+---
+
+该命令类似Docker下的exec，不过这里是在远程的灵雀云的容器中执行命令。
+
+## 依赖
+在Linux、Mac系统中请先安装ssh程序；在Windows系统中也需要安装有ssh功能的程序，例如[plink](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html)。ssh与plink的用法有些地方不一致。目前只支持`ssh`和`plink`。
+
+## 用法
+
+```plain
+$ alauda exec -h
+usage: alauda service exec [-h] [-c CLIENT] [-n NAMESPACE] [-v]
+                           container command [command ...]
+
+Alauda exec
+
+positional arguments:
+  container             Container instance name, in the form of <service
+                        name>.<container number>, where <container number>
+                        defaults to 0 if absent
+  command               Command to execute
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CLIENT, --client CLIENT
+                        The command name of ssh client, support ssh and plink,
+                        in the form of <ssh_client>:<client_path>, where
+                        <client_path> defaults to the same as ssh_client if
+                        absent. The default is ssh
+  -n NAMESPACE, --namespace NAMESPACE
+                        Service namespace
+  -v, --verbose         show more info
+```
+
+以下示例中假定登录用户名为`user01`。
+
+### 示例1
+```plain
+$ alauda exec -v first ls /
+[alauda info] service name: first
+[alauda info] namespace: user01
+[alauda info] ssh client: ssh
+[alauda info] the path of ssh client: ssh
+[alauda info] command: ssh -p 4022 -t user01@exec.alauda.cn first ls /
+user01@exec.alauda.cn's password:
+bin   dev  home  lib64	mnt  proc  run.sh  selinux	   srv	tmp  var
+boot  etc  lib	 media	opt  root  sbin    set_root_pw.sh  sys	usr
+Connection to exec.alauda.cn closed.
+[alauda] OK
+```
+上面的命令，是在已登录用户`user01`的`first`服务下的容器实例0（默认是容器实例0）中执行命令`ls -l`。
+如果是使用当前用户第一次对某服务下的容器实例执行exec，
+会在配置文件`~/.alaudacfg`中添加从alauda网络API中抓取的exec_endpoint信息：
+```json
+{
+  "username": "user01",
+  "exec_endpoint": {
+    "first": "exec.alauda.cn"
+  },
+  "auth": {
+    "token": "**************",
+    "endpoint": "https://api.alauda.cn/v1/"
+  }
+}
+```
+这样下次可以直接从配置文件中取得`exec_endpoint`信息，而不是再次从网络中抓取。
+
+若未指定ssh客户端，默认为ssh命令。
+
+## 示例2
+
+在未登录的情况下使用exec。
+
+退出当前登录。
+```plain
+$ alauda logout
+[alauda] Bye
+[alauda] OK
+```
+
+指定命名空间（这里是用户名），使用exec：
+```plain
+$ alauda exec -v -n user01 first ls /
+[alauda info] use default exec endpoint: exec.alauda.cn
+[alauda info] namespace: user01
+[alauda info] ssh client: ssh
+[alauda info] the path of ssh client: ssh
+[alauda info] command: ssh -p 4022 -t user01@exec.alauda.cn first ls /
+user01@exec.alauda.cn's password:
+bin   dev  home  lib64	mnt  proc  run.sh  selinux	   srv	tmp  var
+boot  etc  lib	 media	opt  root  sbin    set_root_pw.sh  sys	usr
+Connection to exec.alauda.cn closed.
+[alauda] OK
+```
+
+在未登录的情况下使用`exec`，`exec_endpoint`使用默认值`exec.alauda.cn`。
+
+## 示例3
+```plain
+$ alauda exec -v -c ssh:/usr/bin/ssh -n user01 first.0 /bin/bash
+[alauda info] use default exec endpoint: exec.alauda.cn
+[alauda info] namespace: user01
+[alauda info] ssh client: ssh
+[alauda info] the path of ssh client: /usr/bin/ssh
+[alauda info] command: /usr/bin/ssh -p 4022 -t user01@exec.alauda.cn first.0 /bin/bash
+user01@exec.alauda.cn's password:
+root@0a9351f8ade4:/# ls /
+bin   dev  home  lib64	mnt  proc  run.sh  selinux	   srv	tmp  var
+boot  etc  lib	 media	opt  root  sbin    set_root_pw.sh  sys	usr
+```
+`-c ssh:/usr/bin/ssh`是指使用ssh命令，这个命令路径是`/usr/bin/ssh`，这种方法适用于系统PATH中找不到ssh命令这一情况。
+`first.0`是指`first`服务下的容器实例0。
+
+如果要使用plink，可以这样做：
+```plain
+$ alauda exec -v -c plink -n user01 first.0 /bin/bash
+```
+或者
+```plain
+$ alauda exec -v -c plink:/path/to/plink -n user01 first.0 /bin/bash
+```


### PR DESCRIPTION
调用OS中支持ssh的程序实现了exec功能，无其他的python库依赖，具有比较完善的异常处理，文档较详细。主要代码逻辑在`alaudacli/execute.py`中，其他的代码只在必要的地方做了改动以支持exec。exec的代码实现对之前的代码侵入极少。